### PR TITLE
chore: revert google-cloud-shared-dependencies upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.13.0</version>
+        <version>3.8.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This shouldn't have been merged as it's failing the build.

Reverts GoogleCloudPlatform/alloydb-java-connector#66