### PR TITLE
chore: update release-trigger.yml

### DIFF
--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,1 +1,2 @@
 enabled: true
+multiScmName: alloydb-java-connector


### PR DESCRIPTION
This line is necessary for Java-based releases and needs to match the internal configuration.