### PR TITLE
chore: move the modules section before the build section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,10 @@
     </dependencies>
   </dependencyManagement>
 
+  <modules>
+    <module>alloydb-jdbc-connector</module>
+  </modules>
+
   <build>
     <pluginManagement>
       <plugins>
@@ -169,9 +173,5 @@
       </build>
     </profile>
   </profiles>
-
-  <modules>
-    <module>alloydb-jdbc-connector</module>
-  </modules>
 
 </project>


### PR DESCRIPTION
Moving the modules section before the build section for the `publish_javadoc11` script to finish successfully