### PR TITLE
fix: re-use existing connection info during force refresh

### DIFF
--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultConnectionInfoCache.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultConnectionInfoCache.java
@@ -187,8 +187,7 @@ class DefaultConnectionInfoCache implements ConnectionInfoCache {
               "[%s] Force Refresh: the next refresh operation was cancelled."
                   + " Scheduling new refresh operation immediately.",
               instanceName));
-      current = executor.submit(this::performRefresh);
-      next = current;
+      next = executor.submit(this::performRefresh);
     }
   }
 }

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/InMemoryConnectionInfoRepo.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/InMemoryConnectionInfoRepo.java
@@ -55,4 +55,8 @@ class InMemoryConnectionInfoRepo implements ConnectionInfoRepository {
   public final void addResponses(Callable<ConnectionInfo>... callables) {
     registeredCallables.addAll(Arrays.asList(callables));
   }
+
+  public final int getIndex() {
+    return this.index.get();
+  }
 }


### PR DESCRIPTION
Fixes #172 