### PR TITLE
chore: add label to dependency dashboard in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,7 @@
   "commitMessagePrefix": "deps: ",
   "semanticCommits": "enabled",
   "dependencyDashboard": true,
+  "dependencyDashboardLabels": ["type:process"],
   "packageRules": [
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Fixes #219