### PR TITLE
chore: use CaCert from resp body

### DIFF
--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConnectionInfo.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConnectionInfo.java
@@ -27,16 +27,19 @@ class ConnectionInfo {
   private final String instanceUid;
   private final X509Certificate clientCertificate;
   private final List<X509Certificate> certificateChain;
+  private final X509Certificate caCertificate;
 
   ConnectionInfo(
       String ipAddress,
       String instanceUid,
       X509Certificate clientCertificate,
-      List<X509Certificate> certificateChain) {
+      List<X509Certificate> certificateChain,
+      X509Certificate caCertificate) {
     this.ipAddress = ipAddress;
     this.instanceUid = instanceUid;
     this.clientCertificate = clientCertificate;
     this.certificateChain = certificateChain;
+    this.caCertificate = caCertificate;
   }
 
   String getIpAddress() {
@@ -59,6 +62,10 @@ class ConnectionInfo {
     return certificateChain;
   }
 
+  X509Certificate getCaCertificate() {
+    return caCertificate;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -72,12 +79,14 @@ class ConnectionInfo {
     return Objects.equal(ipAddress, that.ipAddress)
         && Objects.equal(instanceUid, that.instanceUid)
         && Objects.equal(clientCertificate, that.clientCertificate)
-        && Objects.equal(certificateChain, that.certificateChain);
+        && Objects.equal(certificateChain, that.certificateChain)
+        && Objects.equal(caCertificate, that.caCertificate);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(ipAddress, instanceUid, clientCertificate, certificateChain);
+    return Objects.hashCode(
+        ipAddress, instanceUid, clientCertificate, certificateChain, caCertificate);
   }
 
   @Override
@@ -93,6 +102,8 @@ class ConnectionInfo {
         + clientCertificate
         + ", certificateChain="
         + certificateChain
+        + ", caCertificate="
+        + caCertificate
         + '}';
   }
 }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultConnectionInfoRepository.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultConnectionInfoRepository.java
@@ -69,9 +69,15 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository, Close
       certificateChain.add(parseCertificate(certificateChainByte));
     }
     X509Certificate clientCertificate = certificateChain.get(0);
+    ByteString caCertificateBytes = certificateResponse.getCaCertBytes();
+    X509Certificate caCertificate = parseCertificate(caCertificateBytes);
 
     return new ConnectionInfo(
-        info.getIpAddress(), info.getInstanceUid(), clientCertificate, certificateChain);
+        info.getIpAddress(),
+        info.getInstanceUid(),
+        clientCertificate,
+        certificateChain,
+        caCertificate);
   }
 
   @Override

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ConnectionInfoCacheTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ConnectionInfoCacheTest.java
@@ -71,7 +71,8 @@ public class ConnectionInfoCacheTest {
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), ONE_HOUR_FROM_NOW),
                 Arrays.asList(
                     testCertificates.getIntermediateCertificate(),
-                    testCertificates.getRootCertificate())));
+                    testCertificates.getRootCertificate()),
+                testCertificates.getRootCertificate()));
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
             executor,
@@ -110,13 +111,15 @@ public class ConnectionInfoCacheTest {
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_ID,
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), ONE_HOUR_FROM_NOW),
-                certificateChain),
+                certificateChain,
+                testCertificates.getRootCertificate()),
         () ->
             new ConnectionInfo(
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_ID,
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), TWO_HOURS_FROM_NOW),
-                certificateChain));
+                certificateChain,
+                testCertificates.getRootCertificate()));
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
             executor,
@@ -181,7 +184,8 @@ public class ConnectionInfoCacheTest {
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_ID,
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), ONE_HOUR_FROM_NOW),
-                certificateChain));
+                certificateChain,
+                testCertificates.getRootCertificate()));
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
             executor,
@@ -224,7 +228,8 @@ public class ConnectionInfoCacheTest {
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_ID,
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), ONE_HOUR_FROM_NOW),
-                certificateChain));
+                certificateChain,
+                testCertificates.getRootCertificate()));
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
             executor,
@@ -267,7 +272,8 @@ public class ConnectionInfoCacheTest {
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), ONE_HOUR_FROM_NOW),
                 Arrays.asList(
                     testCertificates.getIntermediateCertificate(),
-                    testCertificates.getRootCertificate())));
+                    testCertificates.getRootCertificate()),
+                testCertificates.getRootCertificate()));
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
             executor,
@@ -299,13 +305,15 @@ public class ConnectionInfoCacheTest {
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_ID,
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), ONE_HOUR_FROM_NOW),
-                certificateChain),
+                certificateChain,
+                testCertificates.getRootCertificate()),
         () ->
             new ConnectionInfo(
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_ID,
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), TWO_HOURS_FROM_NOW),
-                certificateChain));
+                certificateChain,
+                testCertificates.getRootCertificate()));
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
             executor,
@@ -369,19 +377,22 @@ public class ConnectionInfoCacheTest {
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_ID,
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), ONE_HOUR_FROM_NOW),
-                certificateChain),
+                certificateChain,
+                testCertificates.getRootCertificate()),
         () ->
             new ConnectionInfo(
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_ID,
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), TWO_HOURS_FROM_NOW),
-                certificateChain),
+                certificateChain,
+                testCertificates.getRootCertificate()),
         () ->
             new ConnectionInfo(
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_ID,
                 testCertificates.getEphemeralCertificate(keyPair.getPublic(), THREE_HOURS_FROM_NOW),
-                certificateChain));
+                certificateChain,
+                testCertificates.getRootCertificate()));
     DefaultConnectionInfoCache connectionInfoCache =
         new DefaultConnectionInfoCache(
             executor,

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ConnectionInfoTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ConnectionInfoTest.java
@@ -56,7 +56,8 @@ public class ConnectionInfoTest {
             testCertificates.getEphemeralCertificate(testKeyPair.getPublic(), expected),
             Arrays.asList(
                 testCertificates.getIntermediateCertificate(),
-                testCertificates.getRootCertificate()));
+                testCertificates.getRootCertificate()),
+            testCertificates.getRootCertificate());
 
     assertThat(connectionInfo.getClientCertificateExpiration()).isEqualTo(expected);
   }
@@ -74,7 +75,8 @@ public class ConnectionInfoTest {
             ephemeralCertificate,
             Arrays.asList(
                 testCertificates.getIntermediateCertificate(),
-                testCertificates.getRootCertificate()));
+                testCertificates.getRootCertificate()),
+            testCertificates.getRootCertificate());
 
     //noinspection EqualsWithItself
     assertThat(c1.equals(c1)).isTrue();
@@ -87,7 +89,8 @@ public class ConnectionInfoTest {
                 ephemeralCertificate,
                 Arrays.asList(
                     testCertificates.getIntermediateCertificate(),
-                    testCertificates.getRootCertificate())));
+                    testCertificates.getRootCertificate()),
+                testCertificates.getRootCertificate()));
     assertThat(c1)
         .isNotEqualTo(
             new ConnectionInfo(
@@ -96,7 +99,8 @@ public class ConnectionInfoTest {
                 ephemeralCertificate,
                 Arrays.asList(
                     testCertificates.getIntermediateCertificate(),
-                    testCertificates.getRootCertificate())));
+                    testCertificates.getRootCertificate()),
+                testCertificates.getRootCertificate()));
     assertThat(c1)
         .isNotEqualTo(
             new ConnectionInfo(
@@ -106,7 +110,8 @@ public class ConnectionInfoTest {
                     testKeyPair.getPublic(), Instant.now().plus(1, ChronoUnit.DAYS)),
                 Arrays.asList(
                     testCertificates.getIntermediateCertificate(),
-                    testCertificates.getRootCertificate())));
+                    testCertificates.getRootCertificate()),
+                testCertificates.getRootCertificate()));
     assertThat(c1)
         .isNotEqualTo(
             new ConnectionInfo(
@@ -114,7 +119,8 @@ public class ConnectionInfoTest {
                 INSTANCE_UID,
                 testCertificates.getEphemeralCertificate(
                     testKeyPair.getPublic(), Instant.now().plus(1, ChronoUnit.DAYS)),
-                Collections.emptyList()));
+                Collections.emptyList(),
+                testCertificates.getRootCertificate()));
 
     ConnectionInfo c2 =
         new ConnectionInfo(
@@ -123,7 +129,8 @@ public class ConnectionInfoTest {
             ephemeralCertificate,
             Arrays.asList(
                 testCertificates.getIntermediateCertificate(),
-                testCertificates.getRootCertificate()));
+                testCertificates.getRootCertificate()),
+            testCertificates.getRootCertificate());
     assertThat(c1).isEqualTo(c2);
   }
 
@@ -137,7 +144,8 @@ public class ConnectionInfoTest {
             testCertificates.getEphemeralCertificate(testKeyPair.getPublic(), Instant.now()),
             Arrays.asList(
                 testCertificates.getIntermediateCertificate(),
-                testCertificates.getRootCertificate()));
+                testCertificates.getRootCertificate()),
+            testCertificates.getRootCertificate());
 
     assertThat(c1.hashCode()).isEqualTo(getHashCode(c1));
   }
@@ -147,6 +155,7 @@ public class ConnectionInfoTest {
         connectionInfo.getIpAddress(),
         connectionInfo.getInstanceUid(),
         connectionInfo.getClientCertificate(),
-        connectionInfo.getCertificateChain());
+        connectionInfo.getCertificateChain(),
+        connectionInfo.getCaCertificate());
   }
 }

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ITConnectorTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ITConnectorTest.java
@@ -101,7 +101,8 @@ public class ITConnectorTest {
                 clientConnectorKeyPair.getPublic(), Instant.now()),
             Arrays.asList(
                 testCertificates.getIntermediateCertificate(),
-                testCertificates.getRootCertificate())));
+                testCertificates.getRootCertificate()),
+            testCertificates.getRootCertificate()));
     StubConnectionInfoCacheFactory connectionInfoCacheFactory =
         new StubConnectionInfoCacheFactory(stubConnectionInfoCache);
     SSLSocket socket = null;


### PR DESCRIPTION
Instead of extracting the CA cert from `CertificateChain` we should instead use the `CaCert` field of the response body and let the API handle the work of extracting it.