### PR TITLE
chore: use logback-classic dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,8 @@
   "dependencyDashboard": true,
   "dependencyDashboardLabels": ["type: process"],
   "ignoreDeps": [
-    "org.graalvm.sdk:graal-sdk"
+    "org.graalvm.sdk:graal-sdk",
+    "ch.qos.logback:logback-classic"
   ],
   "packageRules": [
     {

--- a/alloydb-jdbc-connector/pom.xml
+++ b/alloydb-jdbc-connector/pom.xml
@@ -60,7 +60,7 @@
           </ignoredDependencies>
           <usedDependencies>
             <!-- This dependency is not used at compile-time. -->
-            <dependency>org.slf4j:slf4j-jdk14</dependency>
+            <dependency>ch.qos.logback:logback-classic</dependency>
           </usedDependencies>
         </configuration>
       </plugin>
@@ -119,9 +119,10 @@
     </dependency>
 
     <dependency> 
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>2.0.9</version>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.3.11</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Use `logback-classic` dependency instead of `slf4j-jdk14` because it is much easier to configure.

Cloud SQL Java Connector uses `logback-classic` (https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/pull/1680).

Note: the last version that supports Java 8 is `1.3.11`.