### PR TITLE
chore: configure GitHub Actions for unit tests to skip pull_request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,8 @@ permissions: read-all
 
 jobs:
   units:
+    # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
+    if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
@@ -57,6 +59,8 @@ jobs:
       env:
         JOB_TYPE: test
   windows:
+    # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
+    if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
     runs-on: windows-latest
     permissions:
       contents: "read"


### PR DESCRIPTION
We should skip `pull_request` event for unit tests as this event does not have access to repo secrets.