### PR TITLE
ci: add Flakybot to unit test builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,6 @@ jobs:
         distribution: zulu
         java-version: ${{matrix.java}}
     - name: Authenticate to Google Cloud
-      # only needed for Flakybot on periodic (schedule) and continuous (push) events
-      if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
       uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
       with:
         workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
@@ -89,8 +87,6 @@ jobs:
         distribution: zulu
         java-version: 8
     - name: Authenticate to Google Cloud
-      # only needed for Flakybot on periodic (schedule) and continuous (push) events
-      if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
       uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
       with:
         workload_identity_provider: ${{ secrets.PROVIDER_NAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
         java-version: ${{matrix.java}}
     - name: Authenticate to Google Cloud
       # only needed for Flakybot on periodic (schedule) and continuous (push) events
-      if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+      #if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
       uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
       with:
         workload_identity_provider: ${{ secrets.PROVIDER_NAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         JOB_TYPE: test
     - name: FlakyBot
       # only run flakybot on periodic (schedule) and continuous (push) events
-      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+      if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
       run: |
         curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
         chmod +x ./flakybot
@@ -98,7 +98,7 @@ jobs:
         JOB_TYPE: test
     - name: FlakyBot
       # only run flakybot on periodic (schedule) and continuous (push) events
-      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+      if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
       run: |
         curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
         ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         JOB_TYPE: test
     - name: FlakyBot
       # only run flakybot on periodic (schedule) and continuous (push) events
-      if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
       run: |
         curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
         chmod +x ./flakybot
@@ -98,7 +98,7 @@ jobs:
         JOB_TYPE: test
     - name: FlakyBot
       # only run flakybot on periodic (schedule) and continuous (push) events
-      if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+      if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
       run: |
         curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
         ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,10 @@ jobs:
       with:
         distribution: zulu
         java-version: ${{matrix.java}}
-    - uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
+    - name: Authenticate to Google Cloud
+      # only needed for Flakybot on periodic (schedule) and continuous (push) events
+      if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+      uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
       with:
         workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
         service_account: ${{ secrets.SERVICE_ACCOUNT }}
@@ -58,6 +61,14 @@ jobs:
     - run: .kokoro/build.sh
       env:
         JOB_TYPE: test
+    - name: FlakyBot
+      # only run flakybot on periodic (schedule) and continuous (push) events
+      if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+      run: |
+        curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
+        chmod +x ./flakybot
+        ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
   windows:
     # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
     if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
@@ -77,7 +88,10 @@ jobs:
       with:
         distribution: zulu
         java-version: 8
-    - uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
+    - name: Authenticate to Google Cloud
+      # only needed for Flakybot on periodic (schedule) and continuous (push) events
+      if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+      uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
       with:
         workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
         service_account: ${{ secrets.SERVICE_ACCOUNT }}
@@ -86,6 +100,13 @@ jobs:
     - run: .kokoro/build.bat
       env:
         JOB_TYPE: test
+    - name: FlakyBot
+      # only run flakybot on periodic (schedule) and continuous (push) events
+      if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+      run: |
+        curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
+        ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
   dependencies:
     runs-on: ubuntu-latest
     strategy:
@@ -102,6 +123,7 @@ jobs:
         java-version: ${{matrix.java}}
     - run: java -version
     - run: .kokoro/dependencies.sh
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -117,6 +139,7 @@ jobs:
     - run: .kokoro/build.sh
       env:
         JOB_TYPE: lint
+
   clirr:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
         java-version: ${{matrix.java}}
     - name: Authenticate to Google Cloud
       # only needed for Flakybot on periodic (schedule) and continuous (push) events
-      #if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+      if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
       uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
       with:
         workload_identity_provider: ${{ secrets.PROVIDER_NAME }}


### PR DESCRIPTION
Currently Flakybot is not being run on the `units` and `windows` builds. This PR enables it to run on the given builds.
