### PR TITLE
chore: skip dep commits during changelog generation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -85,64 +85,19 @@
       "groupName": "alloydb BOM & shared dependencies"
     },
     {
-      "matchPackagePatterns": [
-        "^attrs",
-        "^cachetools",
-        "^certifi",
-        "^cffi",
-        "^charset-normalizer",
-        "^click",
-        "^colorlog",
-        "^cryptography",
-        "^gcp-docuploader",
-        "^gcp-releasetool",
-        "^google-api-core",
-        "^google-auth",
-        "^google-cloud",
-        "^google-crc32c",
-        "^google-resumable-media",
-        "^googleapis-common-protos",
-        "^idna",
-        "^importlib-metadata",
-        "^jeepney",
-        "^Jinja2",
-        "^keyring",
-        "^MarkupSafe",
-        "^packaging",
-        "^protobuf",
-        "^pyasn1",
-        "^pycparser",
-        "^PyJWT",
-        "^pyparsing",
-        "^pyperclip",
-        "^python-dateutil",
-        "^requests",
-        "^rsa",
-        "^secretstorage",
-        "^six",
-        "^typing-extensions",
-        "^urllib3",
-        "^wheel",
-        "^zipp"
-      ],
-      "groupName": "python dependencies for kokoro"
+      "matchDatasources": ["pypi"],
+      "groupName": "python dependencies for kokoro",
+      "commitMessagePrefix": "chore(deps):"
     },
     {
-      "matchPackagePatterns": [
-        "^actions/checkout",
-        "^actions/github-script",
-        "^actions/setup-java",
-        "^actions/upload-artifact",
-        "^dorny/paths-filter",
-        "^github/codeql-action",
-        "^google-github-actions/auth",
-        "^google-github-actions/get-secretmanager-secrets",
-        "^google-github-actions/setup-gcloud",
-        "^micnncim/action-label-syncer",
-        "^ossf/scorecard-action",
-        "^s4u/setup-maven-action"
-      ],
-      "groupName": "dependencies for github"
+      "matchManagers": ["github-actions"],
+      "groupName": "dependencies for github",
+      "commitMessagePrefix": "chore(deps):"
+    },
+    {
+      "matchManagers": ["maven"],
+      "matchDepTypes": ["test"],
+      "commitMessagePrefix": "chore(deps):"
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Fixes #342 

Test/release/github dependencies commits will have prefix `chore(deps)`.

These commits will be ignored by release-please during the CHANGELOG generation.