### PR TITLE
chore: stop updating kokoro deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,7 @@
   "semanticCommits": "enabled",
   "dependencyDashboard": true,
   "dependencyDashboardLabels": ["type: process"],
+  "ignorePaths": [".kokoro/requirements.txt"],
   "ignoreDeps": [
     "org.graalvm.sdk:graal-sdk",
     "ch.qos.logback:logback-classic"
@@ -83,11 +84,6 @@
         "^com.google.cloud:google-cloud-alloydb-bom"
       ],
       "groupName": "alloydb BOM & shared dependencies"
-    },
-    {
-      "matchDatasources": ["pypi"],
-      "groupName": "python dependencies for kokoro",
-      "commitMessagePrefix": "chore(deps):"
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
No need to update kokoro (release tool) dependencies consistently. Other connectors are not doing it.