### PR TITLE
chore: Migrate deprecated GoogleCredentials constructor

### DIFF
--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/DefaultAccessTokenSupplierTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/DefaultAccessTokenSupplierTest.java
@@ -51,7 +51,9 @@ public class DefaultAccessTokenSupplierTest {
   public void testWithValidToken() throws Exception {
     // Google credentials can be refreshed
     GoogleCredentials googleCredentials =
-        new GoogleCredentials(new AccessToken("my-token", Date.from(future))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-token", Date.from(future)))) {
           @Override
           public AccessToken refreshAccessToken() throws IOException {
             refreshCounter.incrementAndGet();
@@ -70,7 +72,9 @@ public class DefaultAccessTokenSupplierTest {
   @Test
   public void testThrowsOnExpiredTokenRefreshNotSupported() throws Exception {
     GoogleCredentials expiredGoogleCredentials =
-        new GoogleCredentials(new AccessToken("my-expired-token", Date.from(past))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-expired-token", Date.from(past)))) {
           @Override
           public AccessToken refreshAccessToken() throws IOException {
             refreshCounter.incrementAndGet();
@@ -89,7 +93,9 @@ public class DefaultAccessTokenSupplierTest {
   public void testThrowsOnExpiredTokenRefreshStillExpired() throws Exception {
 
     GoogleCredentials refreshGetsExpiredToken =
-        new GoogleCredentials(new AccessToken("my-expired-token", Date.from(past))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-expired-token", Date.from(past)))) {
           @Override
           public AccessToken refreshAccessToken() throws IOException {
             refreshCounter.incrementAndGet();
@@ -107,7 +113,9 @@ public class DefaultAccessTokenSupplierTest {
   @Test
   public void testValidOnRefreshSucceeded() throws Exception {
     GoogleCredentials refreshableCredentials =
-        new GoogleCredentials(new AccessToken("my-expired-token", Date.from(past))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-expired-token", Date.from(past)))) {
           @Override
           public AccessToken refreshAccessToken() throws IOException {
             refreshCounter.incrementAndGet();
@@ -126,7 +134,10 @@ public class DefaultAccessTokenSupplierTest {
 
   @Test
   public void throwsErrorForEmptyAccessToken() {
-    GoogleCredentials creds = new GoogleCredentials(new AccessToken("", Date.from(future))) {};
+    GoogleCredentials creds =
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("", Date.from(future)))) {};
     DefaultAccessTokenSupplier supplier =
         new DefaultAccessTokenSupplier(new GoogleCredentialsFactory(creds));
     RuntimeException ex = assertThrows(RuntimeException.class, supplier::getTokenValue);
@@ -137,7 +148,9 @@ public class DefaultAccessTokenSupplierTest {
   @Test
   public void throwsErrorForExpiredAccessToken() {
     GoogleCredentials refreshableCredentials =
-        new GoogleCredentials(new AccessToken("my-expired-token", Date.from(past))) {
+        new GoogleCredentials(
+            GoogleCredentials.newBuilder()
+                .setAccessToken(new AccessToken("my-expired-token", Date.from(past)))) {
           @Override
           public AccessToken refreshAccessToken() throws IOException {
             refreshCounter.incrementAndGet();

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.20.0</version>
+        <version>3.21.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
* Update dependency `com.google.cloud:google-cloud-shared-dependencies` to `v3.21.0`
* Switch from the deprecated constructor `GoogleCredentials(AccessToken)` to the constructor `GoogleCredentials(Builder builder)`.