### PR TITLE
fix: ensure cert refresh recovers from sleep

### DIFF
--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConnectionInfoCache.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConnectionInfoCache.java
@@ -26,4 +26,6 @@ interface ConnectionInfoCache {
   void forceRefresh();
 
   void close();
+
+  void refreshIfExpired();
 }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/Connector.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/Connector.java
@@ -79,7 +79,17 @@ class Connector {
   }
 
   ConnectionInfoCache getConnection(ConnectionConfig config) {
-    return instances.computeIfAbsent(config, k -> createConnectionInfo(config));
+    ConnectionInfoCache instance =
+        instances.computeIfAbsent(config, k -> createConnectionInfo(config));
+
+    // If the client certificate has expired (as when the computer goes to
+    // sleep, and the refresh cycle cannot run), force a refresh immediately.
+    // The TLS handshake will not fail on an expired client certificate. It's
+    // not until the first read where the client cert error will be surfaced.
+    // So check that the certificate is valid before proceeding.
+    instance.refreshIfExpired();
+
+    return instance;
   }
 
   private ConnectionInfoCache createConnectionInfo(ConnectionConfig config) {

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultConnectionInfoCache.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultConnectionInfoCache.java
@@ -64,4 +64,10 @@ class DefaultConnectionInfoCache implements ConnectionInfoCache {
   public void close() {
     refresher.close();
   }
+
+  /** Refresh the certificate if expired */
+  @Override
+  public void refreshIfExpired() {
+    this.refresher.refreshIfExpired();
+  }
 }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/Refresher.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/Refresher.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 /** Handles periodic refresh operations for an instance. */
 class Refresher {
   private static final Logger logger = LoggerFactory.getLogger(Refresher.class);
+  private static final long DEFAULT_CONNECT_TIMEOUT_MS = 45000;
 
   private final ListeningScheduledExecutorService executor;
 
@@ -58,12 +59,15 @@ class Refresher {
   @GuardedBy("connectionInfoGuard")
   private boolean closed;
 
+  @GuardedBy("connectionInfoGuard")
+  private boolean triggerNextRefresh = true;
+
   Refresher(
       String name,
       ListeningScheduledExecutorService executor,
       Supplier<ListenableFuture<ConnectionInfo>> refreshOperation,
       AsyncRateLimiter rateLimiter) {
-    this(name, executor, new RefreshCalculator(), refreshOperation, rateLimiter);
+    this(name, executor, new RefreshCalculator(), refreshOperation, rateLimiter, true);
   }
 
   /**
@@ -74,18 +78,21 @@ class Refresher {
    * @param refreshCalculator the refresh calculator to determine when to start the next refresh.
    * @param refreshOperation The supplier that refreshes the data.
    * @param rateLimiter The rate limiter.
+   * @param triggerNextRefresh The next refresh operation should be triggered.
    */
   Refresher(
       String name,
       ListeningScheduledExecutorService executor,
       RefreshCalculator refreshCalculator,
       Supplier<ListenableFuture<ConnectionInfo>> refreshOperation,
-      AsyncRateLimiter rateLimiter) {
+      AsyncRateLimiter rateLimiter,
+      boolean triggerNextRefresh) {
     this.name = name;
     this.executor = executor;
     this.refreshCalculator = refreshCalculator;
     this.refreshOperation = refreshOperation;
     this.rateLimiter = rateLimiter;
+    this.triggerNextRefresh = triggerNextRefresh;
     synchronized (connectionInfoGuard) {
       forceRefresh();
       this.current = this.next;
@@ -167,6 +174,18 @@ class Refresher {
     }
   }
 
+  /** Force a new refresh of the instance data if the client certificate has expired. */
+  void refreshIfExpired() {
+    ConnectionInfo info = getConnectionInfo(DEFAULT_CONNECT_TIMEOUT_MS);
+    if (Instant.now().isAfter(info.getExpiration())) {
+      logger.debug(
+          String.format(
+              "[%s] Client certificate has expired. Starting next refresh operation immediately.",
+              name));
+      forceRefresh();
+    }
+  }
+
   /**
    * Triggers an update of internal information obtained from the AlloyDB Admin API, returning a
    * future that resolves once a valid T has been acquired. This sets up a chain of futures that
@@ -210,15 +229,6 @@ class Refresher {
       long secondsToRefresh =
           refreshCalculator.calculateSecondsUntilNextRefresh(Instant.now(), info.getExpiration());
 
-      logger.debug(
-          String.format(
-              "[%s] Refresh Operation: Next operation scheduled at %s.",
-              name,
-              Instant.now()
-                  .plus(secondsToRefresh, ChronoUnit.SECONDS)
-                  .truncatedTo(ChronoUnit.SECONDS)
-                  .toString()));
-
       synchronized (connectionInfoGuard) {
         // Refresh completed successfully, reset forceRefreshRunning.
         refreshRunning = false;
@@ -227,7 +237,16 @@ class Refresher {
 
         // Now update nextInstanceData to perform a refresh after the
         // scheduled delay
-        if (!closed) {
+        if (!closed && triggerNextRefresh) {
+          logger.debug(
+              String.format(
+                  "[%s] Refresh Operation: Next operation scheduled at %s.",
+                  name,
+                  Instant.now()
+                      .plus(secondsToRefresh, ChronoUnit.SECONDS)
+                      .truncatedTo(ChronoUnit.SECONDS)
+                      .toString()));
+
           next =
               Futures.scheduleAsync(
                   this::startRefreshAttempt, secondsToRefresh, TimeUnit.SECONDS, executor);

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ITConnectorTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ITConnectorTest.java
@@ -146,6 +146,7 @@ public class ITConnectorTest {
     }
 
     assertThat(stubConnectionInfoCache.hasForceRefreshed()).isTrue();
+    assertThat(stubConnectionInfoCache.hasRefreshedIfExpired()).isTrue();
     assertThat(stubConnectionInfoCache.hasClosed()).isFalse();
   }
 

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/StubConnectionInfoCache.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/StubConnectionInfoCache.java
@@ -21,6 +21,7 @@ public class StubConnectionInfoCache implements ConnectionInfoCache {
 
   private final AtomicBoolean forceRefreshWasCalled = new AtomicBoolean(false);
   private final AtomicBoolean closeWasCalled = new AtomicBoolean(false);
+  private final AtomicBoolean refreshIfExpiredWasCalled = new AtomicBoolean(false);
   private ConnectionInfo connectionInfo;
 
   @Override
@@ -38,12 +39,21 @@ public class StubConnectionInfoCache implements ConnectionInfoCache {
     closeWasCalled.set(true);
   }
 
+  @Override
+  public void refreshIfExpired() {
+    refreshIfExpiredWasCalled.set(true);
+  }
+
   public boolean hasForceRefreshed() {
     return forceRefreshWasCalled.get();
   }
 
   public boolean hasClosed() {
     return closeWasCalled.get();
+  }
+
+  public boolean hasRefreshedIfExpired() {
+    return refreshIfExpiredWasCalled.get();
   }
 
   public void setConnectionInfo(ConnectionInfo connectionInfo) {


### PR DESCRIPTION
When a computer wakes from sleep after more than ~1 hour and a client tries to connect, the internal certificate cache will have an expired certificate. As a result, clients who tried to connect after sleep would see bad certificate errors which would resolve only once the remaining refresh duration expired (sleep time + remaining duration).

This commit adds code to check if the client certificate is expired and immediately triggers a blocking refresh if it is. This means that in the case where a cached certificate has expired, it will be discarded and a new one will be retrieved before continuing with the connection.

Fixes #386