### PR TITLE
chore: remove support contract reference from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -20,14 +20,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for stopping by to let us know something could be better!<br/>
-        ### PLEASE READ PRIOR TO CREATING BUG
-        If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing it here on GitHub. This will ensure a timely response.
-        
+        Thanks for stopping by to let us know something could be better!
+
         Please run down the following list and make sure you've tried the usual "quick fixes":
         - Search the [current open issues](https://github.com/GoogleCloudPlatform/alloydb-java-connector/issues)
         - Check for answers on [StackOverflow](https://stackoverflow.com/questions/tagged/google-alloydb) (under the 'google-alloydb' tag)
-        
+
         If you are still having issues, please include as much information as possible below! :smile:
   - type: textarea
     id: bug-description

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -20,13 +20,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for stopping by to let us know something could be better!<br/>
-        ### PLEASE READ PRIOR TO CREATING FEATURE REQUEST
-        If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing it here on GitHub. This will ensure a timely response.
-        
+        Thanks for stopping by to let us know something could be better!
+
         Please run down the following list before proceeding with your feature request:
         - Search the [current open issues](https://github.com/GoogleCloudPlatform/alloydb-java-connector/issues) to prevent creating a duplicate.
-        
+
         Please include as much information as possible below! :smile:
   - type: textarea
     id: feature-description

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -20,14 +20,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for stopping by to let us know something could be better!<br/>
-        ### PLEASE READ PRIOR TO CREATING QUESTION
-        If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing it here on GitHub. This will ensure a timely response.
-        
+        Thanks for stopping by to let us know something could be better!
+
         Please run down the following list and make sure you've tried the usual "quick fixes":
         - Search the [current open issues](https://github.com/GoogleCloudPlatform/alloydb-java-connector/issues) for a similar question
         - Check for answers on [StackOverflow](https://stackoverflow.com/questions/tagged/google-alloydb) (under the 'google-alloydb' tag)
-        
+
         If you still have a question, please include as much information as possible below! :smile:
   - type: textarea
     id: question


### PR DESCRIPTION
If a person has made it to GitHub, they almost certainly have an issue with the library and don't need to circle back to support. By removing this phrase, we don't confuse customers and make it clear that we're happy to engage here. If a customer does in fact have a support issue, we can direct them accordingly.