### PR TITLE
feat: add support for PSC

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -5,3 +5,4 @@ export ALLOYDB_INSTANCE_NAME="projects/<PROJECT>/locations/<REGION>/clusters/<CL
 export ALLOYDB_INSTANCE_IP="some-IP-address"
 export ALLOYDB_IAM_USER="some-user@my-project.iam"
 export ALLOYDB_IMPERSONATED_USER="some-impersonated-IAM-user"
+export ALLOYDB_PSC_INSTANCE_URI="projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE>"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,6 +224,7 @@ jobs:
           ALLOYDB_IAM_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/ALLOYDB_JAVA_IAM_USER
           ALLOYDB_INSTANCE_IP:${{ secrets.GOOGLE_CLOUD_PROJECT }}/ALLOYDB_INSTANCE_IP
           ALLOYDB_IMPERSONATED_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/IMPERSONATED_USER
+          ALLOYDB_PSC_INSTANCE_URI:${{ secrets.GOOGLE_CLOUD_PROJECT }}/ALLOYDB_PSC_INSTANCE_URI
 
     - name: Run tests
       env:
@@ -234,6 +235,7 @@ jobs:
         ALLOYDB_INSTANCE_NAME: '${{ steps.secrets.outputs.ALLOYDB_INSTANCE_NAME }}'
         ALLOYDB_INSTANCE_IP: '${{ steps.secrets.outputs.ALLOYDB_INSTANCE_IP }}'
         ALLOYDB_IMPERSONATED_USER: '${{ steps.secrets.outputs.ALLOYDB_IMPERSONATED_USER }}'
+        ALLOYDB_PSC_INSTANCE_URI: '${{ steps.secrets.outputs.ALLOYDB_PSC_INSTANCE_URI }}'
         JOB_TYPE: graalvm17
       run: .kokoro/build.sh
       shell: bash
@@ -307,6 +309,7 @@ jobs:
             ALLOYDB_IAM_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/ALLOYDB_JAVA_IAM_USER
             ALLOYDB_INSTANCE_IP:${{ secrets.GOOGLE_CLOUD_PROJECT }}/ALLOYDB_INSTANCE_IP
             ALLOYDB_IMPERSONATED_USER:${{ secrets.GOOGLE_CLOUD_PROJECT }}/IMPERSONATED_USER
+            ALLOYDB_PSC_INSTANCE_URI:${{ secrets.GOOGLE_CLOUD_PROJECT }}/ALLOYDB_PSC_INSTANCE_URI
 
       - name: Run tests
         env:
@@ -317,6 +320,7 @@ jobs:
           ALLOYDB_INSTANCE_NAME: '${{ steps.secrets.outputs.ALLOYDB_INSTANCE_NAME }}'
           ALLOYDB_INSTANCE_IP: '${{ steps.secrets.outputs.ALLOYDB_INSTANCE_IP }}'
           ALLOYDB_IMPERSONATED_USER: '${{ steps.secrets.outputs.ALLOYDB_IMPERSONATED_USER }}'
+          ALLOYDB_PSC_INSTANCE_URI: '${{ steps.secrets.outputs.ALLOYDB_PSC_INSTANCE_URI }}'
           JOB_TYPE: integration
         run: .kokoro/build.sh
         shell: bash

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConnectionInfo.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConnectionInfo.java
@@ -26,6 +26,7 @@ class ConnectionInfo {
   private final String ipAddress;
   private final String publicIpAddress;
   private final String instanceUid;
+  private final String pscDnsName;
   private final X509Certificate clientCertificate;
   private final List<X509Certificate> certificateChain;
   private final X509Certificate caCertificate;
@@ -33,12 +34,14 @@ class ConnectionInfo {
   ConnectionInfo(
       String ipAddress,
       String publicIpAddress,
+      String pscDnsName,
       String instanceUid,
       X509Certificate clientCertificate,
       List<X509Certificate> certificateChain,
       X509Certificate caCertificate) {
     this.ipAddress = ipAddress;
     this.publicIpAddress = publicIpAddress;
+    this.pscDnsName = pscDnsName;
     this.instanceUid = instanceUid;
     this.clientCertificate = clientCertificate;
     this.certificateChain = certificateChain;
@@ -51,6 +54,10 @@ class ConnectionInfo {
 
   String getPublicIpAddress() {
     return publicIpAddress;
+  }
+
+  String getPscDnsName() {
+    return pscDnsName;
   }
 
   String getInstanceUid() {
@@ -89,6 +96,7 @@ class ConnectionInfo {
     ConnectionInfo that = (ConnectionInfo) o;
     return Objects.equal(ipAddress, that.ipAddress)
         && Objects.equal(publicIpAddress, that.publicIpAddress)
+        && Objects.equal(pscDnsName, that.pscDnsName)
         && Objects.equal(instanceUid, that.instanceUid)
         && Objects.equal(clientCertificate, that.clientCertificate)
         && Objects.equal(certificateChain, that.certificateChain)
@@ -100,6 +108,7 @@ class ConnectionInfo {
     return Objects.hashCode(
         ipAddress,
         publicIpAddress,
+        pscDnsName,
         instanceUid,
         clientCertificate,
         certificateChain,
@@ -114,6 +123,9 @@ class ConnectionInfo {
         + '\''
         + ",publicIpAddress='"
         + publicIpAddress
+        + '\''
+        + ",pscDnsName='"
+        + pscDnsName
         + '\''
         + ", instanceUid='"
         + instanceUid

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultConnectionInfoRepository.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultConnectionInfoRepository.java
@@ -84,6 +84,7 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository, Close
               return new ConnectionInfo(
                   info.getIpAddress(),
                   info.getPublicIpAddress(),
+                  info.getPscDnsName(),
                   info.getInstanceUid(),
                   clientCertificate,
                   certificateChain,

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/IpType.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/IpType.java
@@ -17,5 +17,6 @@ package com.google.cloud.alloydb;
 
 public enum IpType {
   PUBLIC,
-  PRIVATE;
+  PRIVATE,
+  PSC;
 }

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/AlloyDbJdbcPscDataSourceFactory.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/AlloyDbJdbcPscDataSourceFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.alloydb;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+public class AlloyDbJdbcPscDataSourceFactory {
+
+  public static final String ALLOYDB_DB = System.getenv("ALLOYDB_DB");
+  public static final String ALLOYDB_USER = System.getenv("ALLOYDB_USER");
+  public static final String ALLOYDB_PASS = System.getenv("ALLOYDB_PASS");
+  public static final String ALLOYDB_INSTANCE_NAME = System.getenv("ALLOYDB_PSC_INSTANCE_URI");
+
+  static HikariDataSource createDataSource() {
+    HikariConfig config = new HikariConfig();
+
+    config.setJdbcUrl(String.format("jdbc:postgresql:///%s", ALLOYDB_DB));
+    config.setUsername(ALLOYDB_USER); // e.g., "postgres"
+    config.setPassword(ALLOYDB_PASS); // e.g., "secret-password"
+    config.addDataSourceProperty("socketFactory", "com.google.cloud.alloydb.SocketFactory");
+    // e.g., "projects/my-project/locations/us-central1/clusters/my-cluster/instances/my-instance"
+    config.addDataSourceProperty("alloydbInstanceName", ALLOYDB_INSTANCE_NAME);
+    config.addDataSourceProperty("alloydbIpType", "PSC");
+
+    return new HikariDataSource(config);
+  }
+}

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ConnectionInfoCacheTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ConnectionInfoCacheTest.java
@@ -41,6 +41,7 @@ public class ConnectionInfoCacheTest {
 
   private static final String TEST_INSTANCE_IP = "10.0.0.1";
   private static final String TEST_INSTANCE_PUBLIC_IP = "34.0.0.1";
+  private static final String TEST_INSTANCE_DNS_NAME = "abcde.12345.us-central1.alloydb.goog";
   private static final String TEST_INSTANCE_ID = "some-instance-id";
   private static final Instant ONE_HOUR_FROM_NOW = Instant.now().plus(1, ChronoUnit.HOURS);
   private InstanceName instanceName;
@@ -73,6 +74,7 @@ public class ConnectionInfoCacheTest {
             new ConnectionInfo(
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_PUBLIC_IP,
+                TEST_INSTANCE_DNS_NAME,
                 TEST_INSTANCE_ID,
                 TestCertificates.INSTANCE.getEphemeralCertificate(
                     keyPair.getPublic(), ONE_HOUR_FROM_NOW),
@@ -134,6 +136,7 @@ public class ConnectionInfoCacheTest {
             new ConnectionInfo(
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_PUBLIC_IP,
+                TEST_INSTANCE_DNS_NAME,
                 TEST_INSTANCE_ID,
                 TestCertificates.INSTANCE.getEphemeralCertificate(
                     keyPair.getPublic(), ONE_HOUR_FROM_NOW),
@@ -180,6 +183,7 @@ public class ConnectionInfoCacheTest {
             new ConnectionInfo(
                 TEST_INSTANCE_IP,
                 TEST_INSTANCE_PUBLIC_IP,
+                TEST_INSTANCE_DNS_NAME,
                 TEST_INSTANCE_ID,
                 TestCertificates.INSTANCE.getEphemeralCertificate(
                     keyPair.getPublic(), ONE_HOUR_FROM_NOW),

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ConnectionInfoTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ConnectionInfoTest.java
@@ -36,6 +36,7 @@ public class ConnectionInfoTest {
 
   private static final String IP_ADDRESS = "10.0.0.1";
   private static final String PUBLIC_IP_ADDRESS = "34.0.0.1";
+  private static final String DNS_NAME = "abcde.12345.us-central1.alloydb.goog";
   private static final String INSTANCE_UID = "some-id";
   private KeyPair testKeyPair;
 
@@ -52,6 +53,7 @@ public class ConnectionInfoTest {
         new ConnectionInfo(
             IP_ADDRESS,
             PUBLIC_IP_ADDRESS,
+            DNS_NAME,
             INSTANCE_UID,
             TestCertificates.INSTANCE.getEphemeralCertificate(testKeyPair.getPublic(), expected),
             Arrays.asList(
@@ -72,6 +74,7 @@ public class ConnectionInfoTest {
         new ConnectionInfo(
             IP_ADDRESS,
             PUBLIC_IP_ADDRESS,
+            DNS_NAME,
             INSTANCE_UID,
             ephemeralCertificate,
             Arrays.asList(
@@ -87,6 +90,7 @@ public class ConnectionInfoTest {
             new ConnectionInfo(
                 "different IP",
                 PUBLIC_IP_ADDRESS,
+                DNS_NAME,
                 INSTANCE_UID,
                 ephemeralCertificate,
                 Arrays.asList(
@@ -98,6 +102,7 @@ public class ConnectionInfoTest {
             new ConnectionInfo(
                 IP_ADDRESS,
                 "different Public IP",
+                DNS_NAME,
                 INSTANCE_UID,
                 ephemeralCertificate,
                 Arrays.asList(
@@ -109,6 +114,19 @@ public class ConnectionInfoTest {
             new ConnectionInfo(
                 IP_ADDRESS,
                 PUBLIC_IP_ADDRESS,
+                "different DNS name",
+                INSTANCE_UID,
+                ephemeralCertificate,
+                Arrays.asList(
+                    TestCertificates.INSTANCE.getIntermediateCertificate(),
+                    TestCertificates.INSTANCE.getRootCertificate()),
+                TestCertificates.INSTANCE.getRootCertificate()));
+    assertThat(c1)
+        .isNotEqualTo(
+            new ConnectionInfo(
+                IP_ADDRESS,
+                PUBLIC_IP_ADDRESS,
+                DNS_NAME,
                 "different instance Uid",
                 ephemeralCertificate,
                 Arrays.asList(
@@ -120,6 +138,7 @@ public class ConnectionInfoTest {
             new ConnectionInfo(
                 IP_ADDRESS,
                 PUBLIC_IP_ADDRESS,
+                DNS_NAME,
                 INSTANCE_UID,
                 TestCertificates.INSTANCE.getEphemeralCertificate(
                     testKeyPair.getPublic(), Instant.now().plus(1, ChronoUnit.DAYS)),
@@ -132,6 +151,7 @@ public class ConnectionInfoTest {
             new ConnectionInfo(
                 IP_ADDRESS,
                 PUBLIC_IP_ADDRESS,
+                DNS_NAME,
                 INSTANCE_UID,
                 TestCertificates.INSTANCE.getEphemeralCertificate(
                     testKeyPair.getPublic(), Instant.now().plus(1, ChronoUnit.DAYS)),
@@ -142,6 +162,7 @@ public class ConnectionInfoTest {
         new ConnectionInfo(
             IP_ADDRESS,
             PUBLIC_IP_ADDRESS,
+            DNS_NAME,
             "some-id",
             ephemeralCertificate,
             Arrays.asList(
@@ -158,6 +179,7 @@ public class ConnectionInfoTest {
         new ConnectionInfo(
             IP_ADDRESS,
             PUBLIC_IP_ADDRESS,
+            DNS_NAME,
             "some-id",
             TestCertificates.INSTANCE.getEphemeralCertificate(
                 testKeyPair.getPublic(), Instant.now()),
@@ -173,6 +195,7 @@ public class ConnectionInfoTest {
     return Objects.hashCode(
         connectionInfo.getIpAddress(),
         connectionInfo.getPublicIpAddress(),
+        connectionInfo.getPscDnsName(),
         connectionInfo.getInstanceUid(),
         connectionInfo.getClientCertificate(),
         connectionInfo.getCertificateChain(),

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ITConnectorTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ITConnectorTest.java
@@ -109,6 +109,7 @@ public class ITConnectorTest {
         new ConnectionInfo(
             "127.0.0.1", // localhost doesn't do TLS
             "127.0.0.1", // localhost doesn't do TLS
+            "abcde.12345.us-central1.alloydb.goog",
             "some-instance",
             TestCertificates.INSTANCE.getEphemeralCertificate(
                 clientConnectorKeyPair.getPublic(), Instant.now()),

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ITPscTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ITPscTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.alloydb;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ITPscTest {
+
+  private HikariDataSource dataSource;
+
+  @Before
+  public void setUp() {
+    this.dataSource = AlloyDbJdbcPscDataSourceFactory.createDataSource();
+  }
+
+  @After
+  public void tearDown() {
+    if (this.dataSource != null) {
+      dataSource.close();
+    }
+  }
+
+  @Test
+  public void testConnect() throws SQLException {
+    try (Connection connection = dataSource.getConnection()) {
+      try (PreparedStatement statement = connection.prepareStatement("SELECT NOW()")) {
+        ResultSet resultSet = statement.executeQuery();
+        resultSet.next();
+        Timestamp timestamp = resultSet.getTimestamp(1);
+        Instant databaseInstant = timestamp.toInstant();
+
+        Instant now = Instant.now();
+        assertThat(databaseInstant)
+            .isIn(
+                Range.range(
+                    now.minus(1, ChronoUnit.MINUTES),
+                    BoundType.CLOSED,
+                    now.plus(1, ChronoUnit.MINUTES),
+                    BoundType.CLOSED));
+      }
+    }
+  }
+}

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/RefresherTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/RefresherTest.java
@@ -585,7 +585,14 @@ public class RefresherTest {
     private final Instant expiration;
 
     ExampleData(Instant expiration) {
-      super("10.1.1.1", "34.1.1.1", "instance", null, null, null);
+      super(
+          "10.1.1.1",
+          "34.1.1.1",
+          "abcde.12345.us-central1.alloydb.goog",
+          "instance",
+          null,
+          null,
+          null);
       this.expiration = expiration;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <project.javadoc.protobufBaseURL>https://googleapis.dev/java/google-api-grpc/latest</project.javadoc.protobufBaseURL>
     <error-prone.version>2.26.1</error-prone.version>
     <native-image.version>0.10.1</native-image.version>
-    <bouncycastle.version>1.78</bouncycastle.version>
+    <bouncycastle.version>1.77</bouncycastle.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
AlloyDB will soon support PSC-based connections. This commit adds support for PSC in the Java Connector by exposing a new `alloydbIpType=PSC`. When the option is set, the Java Connector retrieves the PSC DNS name from the connection info response and then attempts to connect to that DNS name.

Presently, PSC requires some additional setup on the caller's part (e.g., creation of a Cloud DNS managed zone, with an A record pointing to the PSC service attachment). Those configuration details will be provided elsewhere and not here.

Fixes #445