### PR TITLE
chore: run only unit tests with code coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,8 @@ jobs:
       run: .kokoro/build.sh
       env:
         JOB_TYPE: test
+    - name: Check Coverage
+      run: .kokoro/check_coverage.sh
     - name: FlakyBot
       # only run flakybot on periodic (schedule) and continuous (push) events
       if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
@@ -106,6 +108,8 @@ jobs:
       run: .kokoro/build.bat
       env:
         JOB_TYPE: test
+    - name: Check Coverage
+      run: .kokoro/check_coverage.sh
     - name: FlakyBot
       # only run flakybot on periodic (schedule) and continuous (push) events
       if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
@@ -316,10 +320,6 @@ jobs:
           JOB_TYPE: integration
         run: .kokoro/build.sh
         shell: bash
-
-      - name: Check Coverage
-        run: .kokoro/check_coverage.sh
-
 
       - name: FlakyBot
         # only run flakybot on periodic (schedule) and continuous (push) events

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -42,7 +42,7 @@ set +e
 
 case ${JOB_TYPE} in
 test)
-    mvn test -B -ntp -Dclirr.skip=true -Denforcer.skip=true
+    mvn test -B -ntp -Pcoverage -Dclirr.skip=true -Denforcer.skip=true
     RETURN_CODE=$?
     ;;
 lint)
@@ -56,7 +56,6 @@ javadoc)
 integration)
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \
-      -Pcoverage \
       -Penable-integration-tests \
       -DtrimStackTrace=false \
       -Dclirr.skip=true \

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
               </execution>
               <execution>
                 <id>report</id>
-                <phase>post-integration-test</phase>
+                <phase>test</phase>
                 <goals>
                   <goal>report</goal>
                 </goals>


### PR DESCRIPTION
Currently we check code coverage after executing unit tests and end-to-end (e2e) tests. However we should check code coverage only for unit tests.