### PR TITLE
chore(deps): Update dependency com.google.cloud:google-cloud-shared-dependencies to v3.28.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.27.0</version>
+        <version>3.28.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -153,6 +153,11 @@
         <groupId>org.graalvm.sdk</groupId>
         <artifactId>graal-sdk</artifactId>
         <version>22.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>failureaccess</artifactId>
+        <version>1.0.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Added `com.google.guava:failureaccess` to `<dependencyManagement>` to use the newest version.

To fix this error:

```
Error:  Require upper bound dependencies error for com.google.guava:failureaccess:1.0.1 paths to dependency are:
Error:  +-com.google.cloud:alloydb-jdbc-connector:1.0.1-SNAPSHOT
Error:    +-com.google.api.grpc:proto-google-cloud-alloydb-v1alpha:0.26.0
Error:      +-com.google.guava:failureaccess:1.0.1
Error:  and
Error:  +-com.google.cloud:alloydb-jdbc-connector:1.0.1-SNAPSHOT
Error:    +-com.google.api.grpc:proto-google-cloud-alloydb-connectors-v1:0.15.0
Error:      +-com.google.guava:failureaccess:1.0.1
Error:  and
Error:  +-com.google.cloud:alloydb-jdbc-connector:1.0.1-SNAPSHOT
Error:    +-com.google.api.grpc:grpc-google-cloud-alloydb-v1alpha:0.26.0
Error:      +-com.google.guava:failureaccess:1.0.1
Error:  and
Error:  +-com.google.cloud:alloydb-jdbc-connector:1.0.1-SNAPSHOT
Error:    +-com.google.cloud:google-cloud-alloydb:0.26.0
Error:      +-com.google.guava:failureaccess:1.0.1
Error:  and
Error:  +-com.google.cloud:alloydb-jdbc-connector:1.0.1-SNAPSHOT
Error:    +-com.google.guava:guava:33.1.0-jre
Error:      +-com.google.guava:failureaccess:1.0.2
Error:  and
Error:  +-com.google.cloud:alloydb-jdbc-connector:1.0.1-SNAPSHOT
Error:    +-com.google.cloud:google-cloud-alloydb:0.26.0
Error:      +-com.google.api.grpc:proto-google-cloud-alloydb-v1:0.26.0 (managed) <-- com.google.api.grpc:proto-google-cloud-alloydb-v1:0.26.0
Error:        +-com.google.guava:failureaccess:1.0.1
Error:  and
Error:  +-com.google.cloud:alloydb-jdbc-connector:1.0.1-SNAPSHOT
Error:    +-com.google.cloud:google-cloud-alloydb:0.26.0
Error:      +-com.google.api.grpc:proto-google-cloud-alloydb-v1beta:0.26.0 (managed) <-- com.google.api.grpc:proto-google-cloud-alloydb-v1beta:0.26.0
Error:        +-com.google.guava:failureaccess:1.0.1
Error:  ]
```
