### PR TITLE
Removes duplicate direct dependency of proto-google-cloud-alloydb-v1alpha

### DIFF
--- a/alloydb-jdbc-connector/pom.xml
+++ b/alloydb-jdbc-connector/pom.xml
@@ -81,11 +81,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-google-cloud-alloydb-v1alpha</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-alloydb</artifactId>
     </dependency>


### PR DESCRIPTION
Hey there, another small tidy-up PR. While tracking down some runtime issues (getting a `NoSuchMethodError`) I noticed in my app's dependencies that `proto-google-cloud-alloydb-v1alpha` was defined twice at the top level defintion.

Hoping this (again) is okay without an issue being opened. If not, let me know.

Thanks again,
Andrew