### PR TITLE
fix: Add scope for Credentials

### DIFF
--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConstantCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConstantCredentialFactory.java
@@ -26,8 +26,7 @@ class ConstantCredentialFactory implements CredentialFactory {
 
   public ConstantCredentialFactory(GoogleCredentials credentials) {
     if (credentials.createScopedRequired()) {
-      this.credentials =
-          credentials.createScoped(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM));
+      this.credentials = credentials.createScoped(Arrays.asList(SCOPE_CLOUD_PLATFORM));
     } else {
       this.credentials = credentials;
     }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConstantCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConstantCredentialFactory.java
@@ -18,13 +18,19 @@ package com.google.cloud.alloydb;
 
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.oauth2.GoogleCredentials;
+import java.util.Arrays;
 
 class ConstantCredentialFactory implements CredentialFactory {
 
   private final GoogleCredentials credentials;
 
   public ConstantCredentialFactory(GoogleCredentials credentials) {
-    this.credentials = credentials;
+    if (credentials.createScopedRequired()) {
+      this.credentials =
+          credentials.createScoped(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM));
+    } else {
+      this.credentials = credentials;
+    }
   }
 
   @Override

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/CredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/CredentialFactory.java
@@ -20,6 +20,9 @@ import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.oauth2.GoogleCredentials;
 
 interface CredentialFactory {
+  static final String SCOPE_CLOUD_PLATFORM = "https://www.googleapis.com/auth/cloud-platform";
+  static final String SCOPE_ALLOYDB_LOGIN = "https://www.googleapis.com/auth/alloydb.login";
+
   default FixedCredentialsProvider create() {
     return FixedCredentialsProvider.create(getCredentials());
   }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/CredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/CredentialFactory.java
@@ -21,7 +21,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 
 interface CredentialFactory {
   static final String SCOPE_CLOUD_PLATFORM = "https://www.googleapis.com/auth/cloud-platform";
-  static final String SCOPE_ALLOYDB_LOGIN = "https://www.googleapis.com/auth/alloydb.login";
 
   default FixedCredentialsProvider create() {
     return FixedCredentialsProvider.create(getCredentials());

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultCredentialFactory.java
@@ -18,14 +18,23 @@ package com.google.cloud.alloydb;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
+import java.util.Arrays;
 
 class DefaultCredentialFactory implements CredentialFactory {
   @Override
   public GoogleCredentials getCredentials() {
+    GoogleCredentials credentials;
     try {
-      return GoogleCredentials.getApplicationDefault();
+      credentials = GoogleCredentials.getApplicationDefault();
     } catch (IOException e) {
       throw new RuntimeException("failed to retrieve OAuth2 access token", e);
     }
+
+    if (credentials.createScopedRequired()) {
+      credentials =
+          credentials.createScoped(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM));
+    }
+
+    return credentials;
   }
 }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultCredentialFactory.java
@@ -31,8 +31,7 @@ class DefaultCredentialFactory implements CredentialFactory {
     }
 
     if (credentials.createScopedRequired()) {
-      credentials =
-          credentials.createScoped(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM));
+      credentials = credentials.createScoped(Arrays.asList(SCOPE_CLOUD_PLATFORM));
     }
 
     return credentials;

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/FileCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/FileCredentialFactory.java
@@ -38,8 +38,7 @@ class FileCredentialFactory implements CredentialFactory {
     }
 
     if (credentials.createScopedRequired()) {
-      credentials =
-          credentials.createScoped(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM));
+      credentials = credentials.createScoped(Arrays.asList(SCOPE_CLOUD_PLATFORM));
     }
 
     return credentials;

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/FileCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/FileCredentialFactory.java
@@ -19,6 +19,7 @@ package com.google.cloud.alloydb;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Arrays;
 
 class FileCredentialFactory implements CredentialFactory {
   private final String path;
@@ -29,10 +30,18 @@ class FileCredentialFactory implements CredentialFactory {
 
   @Override
   public GoogleCredentials getCredentials() {
+    GoogleCredentials credentials;
     try {
-      return GoogleCredentials.fromStream(new FileInputStream(path));
+      credentials = GoogleCredentials.fromStream(new FileInputStream(path));
     } catch (IOException e) {
       throw new IllegalStateException("Unable to load GoogleCredentials from file " + path, e);
     }
+
+    if (credentials.createScopedRequired()) {
+      credentials =
+          credentials.createScoped(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM));
+    }
+
+    return credentials;
   }
 }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ServiceAccountImpersonatingCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ServiceAccountImpersonatingCredentialFactory.java
@@ -68,7 +68,7 @@ class ServiceAccountImpersonatingCredentialFactory implements CredentialFactory 
             .setSourceCredentials(credentials)
             .setTargetPrincipal(targetPrincipal)
             .setDelegates(this.delegates)
-            .setScopes(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM))
+            .setScopes(Arrays.asList(SCOPE_CLOUD_PLATFORM))
             .build();
     return credentials;
   }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ServiceAccountImpersonatingCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ServiceAccountImpersonatingCredentialFactory.java
@@ -38,8 +38,6 @@ import java.util.List;
  */
 class ServiceAccountImpersonatingCredentialFactory implements CredentialFactory {
 
-  private static final String CLOUD_PLATFORM = "https://www.googleapis.com/auth/cloud-platform";
-  private static final String ALLOYDB_LOGIN = "https://www.googleapis.com/auth/alloydb.login";
   private final CredentialFactory source;
   private final List<String> delegates;
   private final String targetPrincipal;
@@ -70,7 +68,7 @@ class ServiceAccountImpersonatingCredentialFactory implements CredentialFactory 
             .setSourceCredentials(credentials)
             .setTargetPrincipal(targetPrincipal)
             .setDelegates(this.delegates)
-            .setScopes(Arrays.asList(ALLOYDB_LOGIN, CLOUD_PLATFORM))
+            .setScopes(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM))
             .build();
     return credentials;
   }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/SupplierCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/SupplierCredentialFactory.java
@@ -18,6 +18,7 @@ package com.google.cloud.alloydb;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import java.util.function.Supplier;
+import java.util.Arrays;
 
 class SupplierCredentialFactory implements CredentialFactory {
 
@@ -29,6 +30,13 @@ class SupplierCredentialFactory implements CredentialFactory {
 
   @Override
   public GoogleCredentials getCredentials() {
-    return supplier.get();
+    GoogleCredentials credentials = supplier.get();
+   
+    if (credentials.createScopedRequired()) {
+      credentials =
+          credentials.createScoped(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM));
+    }
+
+    return credentials;
   }
 }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/SupplierCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/SupplierCredentialFactory.java
@@ -33,8 +33,7 @@ class SupplierCredentialFactory implements CredentialFactory {
     GoogleCredentials credentials = supplier.get();
 
     if (credentials.createScopedRequired()) {
-      credentials =
-          credentials.createScoped(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM));
+      credentials = credentials.createScoped(Arrays.asList(SCOPE_CLOUD_PLATFORM));
     }
 
     return credentials;

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/SupplierCredentialFactory.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/SupplierCredentialFactory.java
@@ -17,8 +17,8 @@
 package com.google.cloud.alloydb;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import java.util.function.Supplier;
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 class SupplierCredentialFactory implements CredentialFactory {
 
@@ -31,7 +31,7 @@ class SupplierCredentialFactory implements CredentialFactory {
   @Override
   public GoogleCredentials getCredentials() {
     GoogleCredentials credentials = supplier.get();
-   
+
     if (credentials.createScopedRequired()) {
       credentials =
           credentials.createScoped(Arrays.asList(SCOPE_ALLOYDB_LOGIN, SCOPE_CLOUD_PLATFORM));


### PR DESCRIPTION
The OAuth scopes should be set for the credentials.

When the scopes are missing, the following error is seeing (from https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/2788):


```
Caused by: com.google.auth.oauth2.GoogleAuthException: Error getting access token for service account: 400 Bad Request
POST https://oauth2.googleapis.com/token
***"error":"invalid_scope","error_description":"Invalid OAuth scope or ID token audience provided."***, iss: github-actions-ci@spring-cloud-gcp-ci.iam.gserviceaccount.com
	at com.google.auth.oauth2.GoogleAuthException.createWithTokenEndpointResponseException(GoogleAuthException.java:129)
	at com.google.auth.oauth2.ServiceAccountCredentials.refreshAccessToken(ServiceAccountCredentials.java:538)
	at com.google.auth.oauth2.OAuth2Credentials$1.call(OAuth2Credentials.java:270)
	at com.google.auth.oauth2.OAuth2Credentials$1.call(OAuth2Credentials.java:267)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at com.google.auth.oauth2.OAuth2Credentials$RefreshTask.run(OAuth2Credentials.java:635)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at com.google.auth.oauth2.OAuth2Credentials$AsyncRefreshResult.executeIfNew(OAuth2Credentials.java:582)
	at com.google.auth.oauth2.OAuth2Credentials.asyncFetch(OAuth2Credentials.java:233)
	at com.google.auth.oauth2.OAuth2Credentials.refreshIfExpired(OAuth2Credentials.java:204)
	at com.google.cloud.alloydb.DefaultAccessTokenSupplier.getTokenValue(DefaultAccessTokenSupplier.java:55)
	at com.google.cloud.alloydb.ConnectionSocket.metadataExchange(ConnectionSocket.java:234)
```