### PR TITLE
chore: Update sync-repo-settings.yaml

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -38,7 +38,7 @@ branchProtectionRules:
   # Defaults to `false`
   requiresCodeOwnerReviews: true
   # Require up to date branches
-  requiresStrictStatusChecks: true
+  requiresStrictStatusChecks: false
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
   - "dependencies (11)"


### PR DESCRIPTION
Don't require PRs to be up-to-date. Requiring this check is
only useful when there is a steady stream of feature work. 
Meanwhile, when merging dependencies updates, we have
to run the CI checks repeatedly for little value. So disable the
check for the branch to be up-to-date.