### PR TITLE
chore: Update renovate.json5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -81,7 +81,9 @@
     {
       "matchPackagePatterns": [
         "^com.google.cloud:google-cloud-shared-dependencies",
-        "^com.google.cloud:google-cloud-alloydb-bom"
+        "^com.google.cloud:google-cloud-alloydb-bom",
+        "^com.google.api:gax-grpc",
+        "^com.google.cloud:google-cloud-alloydb-connectors-bom"
       ],
       "groupName": "alloydb BOM & shared dependencies"
     },


### PR DESCRIPTION
Add additional shared dependencies. GAX gRPC and alloydb-connectors-bom all
need to go together to avoid dependency conflicts.