### PR TITLE
chore: skip integration tests on forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -249,6 +249,11 @@ jobs:
   unitsAndE2e:
     name: units + e2e
     runs-on: [self-hosted, linux, x64]
+    # run integration tests on all builds except pull requests from forks
+    # or dependabot
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
GitHub provides no reasonable and secure way to run integration tests against PRs from forks. This PR adjusts the CI builds to skip integration tests on PRs from forks and otherwise runs the entire test suite for internal PRs. In addition, integration tests will run on main regardless to catch any regressions.