### PR TITLE
ci: use graalvm-community and native image maven plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -200,10 +200,10 @@ jobs:
         java-version: 17
 
     - name: Set up GraalVM
-      uses: graalvm/setup-graalvm@22cc13fe88ef133134b3798e128fb208df55e1f5 # v1
+      uses: graalvm/setup-graalvm@2911b2304bee2c2f59b9a67bf45f025a6b6de4b1 # v1.2.2
       with:
-        distribution: "graalvm"
-        java-version: "17"
+        java-version: "21"
+        distribution: "graalvm-community"
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - id: "auth"

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
     <site.installationModule>alloydb-connector-parent</site.installationModule>
     <project.javadoc.protobufBaseURL>https://googleapis.dev/java/google-api-grpc/latest</project.javadoc.protobufBaseURL>
     <error-prone.version>2.30.0</error-prone.version>
-    <native-image.version>0.10.2</native-image.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>
   </properties>
 
@@ -290,7 +289,7 @@
         <dependency>
           <groupId>org.graalvm.buildtools</groupId>
           <artifactId>junit-platform-native</artifactId>
-          <version>${native-image.version}</version>
+          <version>${native-maven-plugin.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -299,7 +298,7 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>${native-image.version}</version>
+            <version>${native-maven-plugin.version}</version>
             <extensions>true</extensions>
             <executions>
               <execution>


### PR DESCRIPTION
This change sets up to use a managed GraalVM test image.

See https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/pull/2030.

Fixes #561.