### PR TITLE
chore: manage JUnit deps separately

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,9 +27,17 @@
       "matchUpdateTypes": ["minor", "patch"],
     },
     {
-      "matchManagers": ["github-actions"],
       "groupName": "dependencies for github",
+      "matchManagers": ["github-actions"],
       "commitMessagePrefix": "chore(deps):"
+    },
+    {
+        "groupName": "JUnit dependencies",
+        "matchPackagePatterns": [
+            "^org.junit.platform:junit-platform-engine",
+            "^org.junit.platform:junit-platform-commons",
+            "^org.junit.vintage:junit-vintage-engine",
+        ]
     },
   ]
 }


### PR DESCRIPTION
The GraalVM build broke when we updated the JUnit dependencies. Rather than disable upgrades, this PR splits out the dependencies as a separate rule to make it easier to catch problems in the future.

Related to https://github.com/GoogleCloudPlatform/alloydb-java-connector/issues/574