### PR TITLE
chore: fix GraalVM nightly build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,12 +269,12 @@
           <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-engine</artifactId>
-            <version>1.11.0</version>
+            <version>1.10.3</version>
           </dependency>
           <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-commons</artifactId>
-            <version>1.11.0</version>
+            <version>1.10.3</version>
           </dependency>
         </dependencies>
       </dependencyManagement>
@@ -283,7 +283,7 @@
         <dependency>
           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>
-          <version>5.11.0</version>
+          <version>5.10.3</version>
           <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Restore older versions of JUnit platform components.

Tested by:

docker run -it -v $PWD:/code --rm ghcr.io/graalvm/graalvm-community:22 bash

And then running tests.

Fixes #574