### PR TITLE
chore: upgrade and specify all JUnit transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,12 +269,32 @@
           <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-engine</artifactId>
-            <version>1.10.3</version>
+            <version>1.11.2</version>
           </dependency>
           <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-commons</artifactId>
-            <version>1.10.3</version>
+            <version>1.11.2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.11.2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.2</version>
           </dependency>
         </dependencies>
       </dependencyManagement>
@@ -283,7 +303,7 @@
         <dependency>
           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>
-          <version>5.10.3</version>
+          <version>5.11.2</version>
           <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This resolves the error we're seeing in our nightly GraalVM builds:

TestEngine with ID 'junit-jupiter' failed to discover tests

It also pulls in the latest JUnit dependencies.

Fixes https://github.com/GoogleCloudPlatform/alloydb-java-connector/issues/585