### PR TITLE
chore: improve renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,11 +43,9 @@
       commitMessagePrefix: 'chore(deps):',
     },
     {
-      groupName: 'JUnit dependencies',
+      groupName: 'error-prone-core',
       matchPackageNames: [
-        '/^org.junit.platform:junit-platform-engine/',
-        '/^org.junit.platform:junit-platform-commons/',
-        '/^org.junit.vintage:junit-vintage-engine/',
+        '/^com.google.errorprone:error_prone_core/',
       ],
     },
   ],


### PR DESCRIPTION
JUnit is no longer a problem as we've addressed the underlying dependency issue in prior changes.

Error Prone core dropped support for JDK 11 in v2.32.0 [1]. So for now, update Error Prone core separately to make it easier to fix the issue without breaking our usual dependency updates.

[1]: https://github.com/google/error-prone/releases/tag/v2.31.0