### PR TITLE
fix: use daemon threads internally

### DIFF
--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/InternalConnectorRegistry.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/InternalConnectorRegistry.java
@@ -65,7 +65,15 @@ enum InternalConnectorRegistry implements Closeable {
     // there should be enough free threads so that there will not be a deadlock. Most users
     // configure 3 or fewer instances, requiring 6 threads during refresh. By setting
     // this to 8, it's enough threads for most users, plus a safety factor of 2.
-    this.executor = MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(8));
+    this.executor =
+        MoreExecutors.listeningDecorator(
+            Executors.newScheduledThreadPool(
+                8,
+                r -> {
+                  Thread t = new Thread(r);
+                  t.setDaemon(true);
+                  return t;
+                }));
     this.unnamedConnectors = new ConcurrentHashMap<>();
     this.namedConnectors = new ConcurrentHashMap<>();
     this.credentialFactoryProvider = new CredentialFactoryProvider();


### PR DESCRIPTION
Without using daemon threads, the Connector will prevent a calling process from exiting cleanly.

Fixes #617