### PR TITLE
chore: make connector tests run locally

### DIFF
--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ConnectorTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/ConnectorTest.java
@@ -28,121 +28,62 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ConnectorTest {
 
   private static final String INSTANCE_NAME =
       "projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE>";
-  private static final String PRIVATE_IP = "127.0.0.2";
-  private static final String DNS_NAME = "localhost";
   private static final String SERVER_MESSAGE = "HELLO";
   private static final String ERROR_MESSAGE_NOT_FOUND = "Resource 'instance' was not found";
-  private static final String ERROR_MESSAGE_PERMISSION_DENIED =
-      "Location not found or access is unauthorized.";
-  private static final String ERROR_MESSAGE_INTERNAL = "Internal Error";
   private static final String USER_AGENT = "unit tests";
 
-  ListeningScheduledExecutorService defaultExecutor;
+  static ListeningScheduledExecutorService defaultExecutor;
+  private static FakeSslServer sslServer;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeClass
+  public static void beforeClass() throws Exception {
     defaultExecutor = MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(8));
+    sslServer = new FakeSslServer(SERVER_MESSAGE);
+    sslServer.start("127.0.0.1");
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void afterClass() {
     defaultExecutor.shutdownNow();
+    sslServer.stop();
   }
 
   @Test
-  public void create_successfulPrivateConnection()
-      throws IOException, InterruptedException, NoSuchAlgorithmException, InvalidKeySpecException {
-    FakeSslServer sslServer = new FakeSslServer(SERVER_MESSAGE);
-    sslServer.start(PRIVATE_IP);
-
+  public void create_successfulPrivateConnection() throws IOException {
+    MockAlloyDBAdminGrpc mock = new MockAlloyDBAdminGrpc("127.0.0.1", IpType.PRIVATE);
     ConnectionConfig config =
         new ConnectionConfig.Builder().withInstanceName(InstanceName.parse(INSTANCE_NAME)).build();
-
-    MockAlloyDBAdminGrpc mock = new MockAlloyDBAdminGrpc(PRIVATE_IP, IpType.PRIVATE);
     Connector connector = newConnector(config.getConnectorConfig(), mock);
+
     Socket socket = connector.connect(config);
 
     assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
-    sslServer.stop();
   }
 
   @Test
-  public void create_successfulPscConnection()
-      throws IOException, InterruptedException, NoSuchAlgorithmException, InvalidKeySpecException {
-    FakeSslServer sslServer = new FakeSslServer(SERVER_MESSAGE);
-    sslServer.start(DNS_NAME);
-
-    ConnectionConfig config =
-        new ConnectionConfig.Builder()
-            .withInstanceName(InstanceName.parse(INSTANCE_NAME))
-            .withIpType(IpType.PSC)
-            .build();
-
-    MockAlloyDBAdminGrpc mock = new MockAlloyDBAdminGrpc(DNS_NAME, IpType.PSC);
-    Connector connector = newConnector(config.getConnectorConfig(), mock);
-    Socket socket = connector.connect(config);
-
-    assertThat(readLine(socket)).isEqualTo(SERVER_MESSAGE);
-    sslServer.stop();
-  }
-
-  @Test
-  public void create_throwsTerminalException_notFound()
-      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+  public void create_throwsTerminalException() {
     MockAlloyDBAdminGrpc mock =
         new MockAlloyDBAdminGrpc(Code.NOT_FOUND.getNumber(), ERROR_MESSAGE_NOT_FOUND);
-
     ConnectionConfig config =
         new ConnectionConfig.Builder().withInstanceName(InstanceName.parse(INSTANCE_NAME)).build();
     Connector connector = newConnector(config.getConnectorConfig(), mock);
 
     TerminalException ex = assertThrows(TerminalException.class, () -> connector.connect(config));
+
     assertThat(ex).hasMessageThat().contains(ERROR_MESSAGE_NOT_FOUND);
   }
 
-  @Test
-  public void create_throwsTerminalException_notAuthorized()
-      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
-    MockAlloyDBAdminGrpc mock =
-        new MockAlloyDBAdminGrpc(
-            Code.PERMISSION_DENIED.getNumber(), ERROR_MESSAGE_PERMISSION_DENIED);
-
-    ConnectionConfig config =
-        new ConnectionConfig.Builder().withInstanceName(InstanceName.parse(INSTANCE_NAME)).build();
-    Connector connector = newConnector(config.getConnectorConfig(), mock);
-
-    TerminalException ex = assertThrows(TerminalException.class, () -> connector.connect(config));
-    assertThat(ex).hasMessageThat().contains(ERROR_MESSAGE_PERMISSION_DENIED);
-  }
-
-  @Test
-  public void create_throwsNonTerminalException_internalError()
-      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
-    MockAlloyDBAdminGrpc mock =
-        new MockAlloyDBAdminGrpc(Code.INTERNAL.getNumber(), ERROR_MESSAGE_INTERNAL);
-
-    ConnectionConfig config =
-        new ConnectionConfig.Builder().withInstanceName(InstanceName.parse(INSTANCE_NAME)).build();
-    Connector connector = newConnector(config.getConnectorConfig(), mock);
-
-    RuntimeException ex = assertThrows(RuntimeException.class, () -> connector.connect(config));
-    assertThat(ex).hasMessageThat().contains(ERROR_MESSAGE_INTERNAL);
-  }
-
-  private Connector newConnector(ConnectorConfig config, MockAlloyDBAdminGrpc mock)
-      throws NoSuchAlgorithmException, InvalidKeySpecException {
+  private Connector newConnector(ConnectorConfig config, MockAlloyDBAdminGrpc mock) {
     CredentialFactoryProvider stubCredentialFactoryProvider =
         new CredentialFactoryProvider(new StubCredentialFactory());
     CredentialFactory instanceCredentialFactory =

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/TestCertificates.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/TestCertificates.java
@@ -66,7 +66,7 @@ enum TestCertificates {
   private final String DEFAULT_SERVER_NAME =
       String.format("%s.server.alloydb", DEFAULT_INSTANCE_ID);
   private final String SHA_256_WITH_RSA = "SHA256WithRSA";
-  private final String PRIVATE_IP = "127.0.0.2";
+  private final String PRIVATE_IP = "127.0.0.1";
   private final String DNS_NAME = "localhost";
 
   @SuppressWarnings("ImmutableEnumChecker")


### PR DESCRIPTION
This commit updates the connector tests to run locally. The previous use of 127.0.0.2 does not work on non-Linux machines.

Also, this commit removes superfluous and duplicate tests that verify exception paths, speeding up the test suite at the same time.