### PR TITLE
fix: close AlloyDB gRPC client on connector close

### DIFF
--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConnectionInfoRepository.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/ConnectionInfoRepository.java
@@ -18,8 +18,9 @@ package com.google.cloud.alloydb;
 
 import com.google.cloud.alloydb.v1alpha.InstanceName;
 import com.google.common.util.concurrent.ListenableFuture;
+import java.io.Closeable;
 import java.security.KeyPair;
 
-interface ConnectionInfoRepository {
+interface ConnectionInfoRepository extends Closeable {
   ListenableFuture<ConnectionInfo> getConnectionInfo(InstanceName instanceName, KeyPair publicKey);
 }

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/Connector.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/Connector.java
@@ -61,10 +61,11 @@ class Connector {
     return config;
   }
 
-  public void close() {
+  public void close() throws IOException {
     logger.debug("Close all connections and remove them from cache.");
     this.instances.forEach((key, c) -> c.close());
     this.instances.clear();
+    this.connectionInfoRepo.close();
   }
 
   Socket connect(ConnectionConfig config) throws IOException {

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/InternalConnectorRegistry.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/InternalConnectorRegistry.java
@@ -140,14 +140,32 @@ enum InternalConnectorRegistry implements Closeable {
     if (connector == null) {
       throw new IllegalArgumentException("Named connection " + name + " does not exist.");
     }
-    connector.close();
+    try {
+      connector.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /** Shutdown all connectors. */
   private void shutdownConnectors() {
-    this.unnamedConnectors.forEach((key, c) -> c.close());
+    this.unnamedConnectors.forEach(
+        (key, c) -> {
+          try {
+            c.close();
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        });
     this.unnamedConnectors.clear();
-    this.namedConnectors.forEach((key, c) -> c.close());
+    this.namedConnectors.forEach(
+        (key, c) -> {
+          try {
+            c.close();
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        });
     this.namedConnectors.clear();
   }
 

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/InMemoryConnectionInfoRepo.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/InMemoryConnectionInfoRepo.java
@@ -19,6 +19,7 @@ package com.google.cloud.alloydb;
 import com.google.cloud.alloydb.v1alpha.InstanceName;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import java.io.IOException;
 import java.security.KeyPair;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,5 +56,10 @@ class InMemoryConnectionInfoRepo implements ConnectionInfoRepository {
 
   public final int getIndex() {
     return this.index.get();
+  }
+
+  @Override
+  public void close() throws IOException {
+    // no-op
   }
 }

--- a/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/InternalConnectorRegistryTest.java
+++ b/alloydb-jdbc-connector/src/test/java/com/google/cloud/alloydb/InternalConnectorRegistryTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.alloydb.v1alpha.InstanceName;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Properties;
 import org.junit.Before;
@@ -38,7 +37,7 @@ public class InternalConnectorRegistryTest {
   }
 
   @Test
-  public void create_failOnInvalidInstanceName() throws IOException {
+  public void create_failOnInvalidInstanceName() {
     IllegalArgumentException ex =
         assertThrows(
             IllegalArgumentException.class,
@@ -53,7 +52,7 @@ public class InternalConnectorRegistryTest {
   }
 
   @Test
-  public void create_failOnEmptyTargetPrincipal() throws IOException, InterruptedException {
+  public void create_failOnEmptyTargetPrincipal() {
     IllegalArgumentException ex =
         assertThrows(
             IllegalArgumentException.class,
@@ -72,7 +71,7 @@ public class InternalConnectorRegistryTest {
   }
 
   @Test
-  public void registerConnection_failWithDuplicateName() throws InterruptedException {
+  public void registerConnection_failWithDuplicateName() {
     // Register a Connection
     String namedConnector = "my-connection-name";
     ConnectorConfig configWithDetails = new ConnectorConfig.Builder().build();
@@ -89,8 +88,7 @@ public class InternalConnectorRegistryTest {
   }
 
   @Test
-  public void registerConnection_failWithDuplicateNameAndDifferentConfig()
-      throws InterruptedException {
+  public void registerConnection_failWithDuplicateNameAndDifferentConfig() {
     String namedConnector = "test-connection";
     ConnectorConfig config =
         new ConnectorConfig.Builder().withTargetPrincipal("joe@test.com").build();
@@ -110,7 +108,7 @@ public class InternalConnectorRegistryTest {
   }
 
   @Test
-  public void closeNamedConnection_failWhenNotFound() throws InterruptedException {
+  public void closeNamedConnection_failWhenNotFound() {
     String namedConnector = "a-connection";
     // Assert that you can't close a connection that doesn't exist
     IllegalArgumentException ex =
@@ -123,7 +121,7 @@ public class InternalConnectorRegistryTest {
   }
 
   @Test
-  public void connect_failOnClosedNamedConnection() throws InterruptedException {
+  public void connect_failOnClosedNamedConnection() {
     // Register a Connection
     String namedConnector = "my-connection";
     ConnectorConfig configWithDetails = new ConnectorConfig.Builder().build();
@@ -149,7 +147,7 @@ public class InternalConnectorRegistryTest {
   }
 
   @Test
-  public void connect_failOnUnknownNamedConnection() throws InterruptedException {
+  public void connect_failOnUnknownNamedConnection() {
     // Attempt and fail to connect using the Named Connection not registered
     String namedConnector = "first-connection";
     Properties connProps = new Properties();
@@ -166,7 +164,7 @@ public class InternalConnectorRegistryTest {
   }
 
   @Test
-  public void connect_failOnNamedConnectionAfterResetInstance() throws InterruptedException {
+  public void connect_failOnNamedConnectionAfterResetInstance() {
     // Register a Connection
     String namedConnector = "this-connection";
     ConnectorConfig config = new ConnectorConfig.Builder().build();


### PR DESCRIPTION
When the connector is closed, it must also close the underlying AlloyDB gRPC-based client to avoid any errors. This ensures a clean shutdown of the Connector generally.