### PR TITLE
chore: run GraalVM build regularly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,5 +48,12 @@
         '/^com.google.errorprone:error_prone_core/',
       ],
     },
+    {
+      groupName: 'junit platform dependencies',
+      matchPackageNames: [
+        '/^org.junit.platform:/',
+        '/^org.junit.juputer:/',
+      ],
+    },
   ],
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,8 +179,6 @@ jobs:
         JOB_TYPE: clirr
 
   graalvm17:
-    # run job on periodic (schedule) event
-    if: "${{ github.event_name == 'schedule' }}"
     name: graalvm17
     runs-on: [self-hosted, linux, x64]
     permissions:

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,8 @@
     <error-prone.version>2.31.0</error-prone.version>
     <error-prone-annotations.version>2.37.0</error-prone-annotations.version>
     <bouncycastle.version>1.80</bouncycastle.version>
+    <junit.jupiter.version>5.11.4</junit.jupiter.version>
+    <junit.platform.version>1.11.4</junit.platform.version>
   </properties>
 
   <dependencyManagement>
@@ -270,48 +272,47 @@
           <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-engine</artifactId>
-            <version>1.12.2</version>
+            <version>${junit.platform.version}</version>
           </dependency>
           <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-commons</artifactId>
-            <version>1.12.2</version>
+            <version>${junit.platform.version}</version>
           </dependency>
           <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.12.2</version>
+            <version>${junit.jupiter.version}</version>
           </dependency>
           <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.12.2</version>
+            <version>${junit.jupiter.version}</version>
           </dependency>
           <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.12.2</version>
+            <version>${junit.jupiter.version}</version>
           </dependency>
           <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.12.2</version>
+            <version>${junit.jupiter.version}</version>
           </dependency>
         </dependencies>
       </dependencyManagement>
       <dependencies>
-        <!-- GraalVM native image test needs newer JUnit platform -->
-        <dependency>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-          <version>5.12.2</version>
-          <scope>test</scope>
-        </dependency>
         <dependency>
           <groupId>org.graalvm.buildtools</groupId>
           <artifactId>junit-platform-native</artifactId>
           <version>${native-maven-plugin.version}</version>
           <scope>test</scope>
+          <exclusions>
+            <exclusion>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
       <build>


### PR DESCRIPTION
This will ensure breaking dependency changes are caught sooner, at the
cost of slower builds. Once we better understand how GraalVM builds are
breaking (e.g., Junit deps changes), we can restore the build to nightly.

In addition, this commit downgrades Junit dependencies back to the last
working version and configures a Renovate group so we can address them
separately.

Fixes #627