### PR TITLE
chore: test Java 21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17]
+        # We match the official policy:
+        # https://cloud.google.com/java/docs/supported-java-versions
+        java: [8, 11, 17, 21]
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -121,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [8, 11, 17, 21]
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.kokoro/dependencies.sh
+++ b/.kokoro/dependencies.sh
@@ -38,20 +38,14 @@ function determineMavenOpts() {
       | sed -E 's/^(1\.[0-9]\.0).*$/\1/g'
   )
 
-  if [[ $javaVersion == 17* ]]
-    then
-      # MaxPermSize is no longer supported as of jdk 17
-      echo -n "-Xmx1024m"
-  else
-      echo -n "-Xmx1024m -XX:MaxPermSize=128m"
-  fi
+  echo -n "-Xmx1024m"
 }
 
 export MAVEN_OPTS=$(determineMavenOpts)
 
 # this should run maven enforcer
 retry_with_backoff 3 10 \
-  mvn install -B -V -ntp \
+  ./mvnw install -B -V -ntp \
     -DskipTests=true \
     -Dmaven.javadoc.skip=true \
     -Dclirr.skip=true


### PR DESCRIPTION
This matches the official policy:
https://cloud.google.com/java/docs/supported-java-versions