### PR TITLE
chore: Update blunderbuss.yml

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -14,10 +14,7 @@
 
 assign_issues:
   - enocom
-  - nancynh
-  - rhatgadkar-goog
 
 assign_prs:
   - enocom
   - nancynh
-  - rhatgadkar-goog


### PR DESCRIPTION
Updating automatic assignment to match primary/secondary maintainer roles.