### PR TITLE
chore: group all junit jupiter packages together

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,7 +52,7 @@
       groupName: 'junit platform dependencies',
       matchPackageNames: [
         '/^org.junit.platform:/',
-        '/^org.junit.juputer:/',
+        '/^org.junit.jupiter/',
       ],
     },
   ],


### PR DESCRIPTION
This change ensures all JUnit updates go together in a separate PR.