### PR TITLE
chore: simplify GraalVM config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,10 +180,10 @@ jobs:
       env:
         JOB_TYPE: clirr
 
-  graalvm17:
+  graalvm:
     # run job on periodic (schedule) event
-    if: "${{ github.event_name == 'schedule' }}"
-    name: graalvm17
+    # if: "${{ github.event_name == 'schedule' }}"
+    name: graalvm
     runs-on: [self-hosted, linux, x64]
     permissions:
       contents: "read"
@@ -233,7 +233,7 @@ jobs:
         ALLOYDB_INSTANCE_IP: '${{ steps.secrets.outputs.ALLOYDB_INSTANCE_IP }}'
         ALLOYDB_IMPERSONATED_USER: '${{ steps.secrets.outputs.ALLOYDB_IMPERSONATED_USER }}'
         ALLOYDB_PSC_INSTANCE_URI: '${{ steps.secrets.outputs.ALLOYDB_PSC_INSTANCE_URI }}'
-        JOB_TYPE: graalvm17
+        JOB_TYPE: graalvm
       run: .kokoro/build.sh
       shell: bash
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,7 +182,7 @@ jobs:
 
   graalvm:
     # run job on periodic (schedule) event
-    # if: "${{ github.event_name == 'schedule' }}"
+    if: "${{ github.event_name == 'schedule' }}"
     name: graalvm
     runs-on: [self-hosted, linux, x64]
     permissions:

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -69,11 +69,6 @@ graalvm)
     ./mvnw -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
     RETURN_CODE=$?
     ;;
-graalvm17)
-    # Run Unit and Integration Tests with Native Image
-    ./mvnw -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
-    RETURN_CODE=$?
-    ;;
 samples)
     SAMPLES_DIR=samples
     # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.

--- a/alloydb-jdbc-connector/src/main/resources/META-INF/native-image/com.google.cloud/alloydb-jdbc-connector/reflect-config.json
+++ b/alloydb-jdbc-connector/src/main/resources/META-INF/native-image/com.google.cloud/alloydb-jdbc-connector/reflect-config.json
@@ -4,17 +4,5 @@
         "allDeclaredConstructors": true,
         "allDeclaredFields": true,
         "allDeclaredMethods": true
-    },
-    {
-        "name": "org.postgresql.PGProperty",
-        "allDeclaredConstructors": true,
-        "allDeclaredFields": true,
-        "allDeclaredMethods": true
-    },
-    {
-        "name": "com.zaxxer.hikari.HikariConfig",
-        "allDeclaredConstructors": true,
-        "allDeclaredFields": true,
-        "allDeclaredMethods": true
     }
 ]

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,6 @@
     <error-prone.version>2.31.0</error-prone.version>
     <error-prone-annotations.version>2.38.0</error-prone-annotations.version>
     <bouncycastle.version>1.80</bouncycastle.version>
-    <junit.jupiter.version>5.12.2</junit.jupiter.version>
-    <junit.platform.version>1.11.4</junit.platform.version>
   </properties>
 
   <dependencyManagement>
@@ -252,87 +250,6 @@
                 </configuration>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <!-- This profile is used to enable GraalVM native image testing
-      (.kokoro/graalvm-native/linux) -->
-      <id>native</id>
-      <dependencyManagement>
-        <!-- Controlling version for dependencyConvergence enforcer rule -->
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-engine</artifactId>
-            <version>${junit.platform.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-commons</artifactId>
-            <version>${junit.platform.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${junit.jupiter.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit.jupiter.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
-      <dependencies>
-        <dependency>
-          <groupId>org.graalvm.buildtools</groupId>
-          <artifactId>junit-platform-native</artifactId>
-          <version>${native-maven-plugin.version}</version>
-          <scope>test</scope>
-          <exclusions>
-            <exclusion>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.graalvm.buildtools</groupId>
-            <artifactId>native-maven-plugin</artifactId>
-            <version>${native-maven-plugin.version}</version>
-            <extensions>true</extensions>
-            <executions>
-              <execution>
-                <id>test-native</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <phase>test</phase>
-              </execution>
-            </executions>
-            <configuration>
-              <buildArgs>
-                <buildArg>--no-fallback</buildArg>
-                <buildArg>--no-server</buildArg>
-                <buildArg>-Ob</buildArg>
-              </buildArgs>
-            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
This commit cleans up additional leftovers following #645.

In particular:

- Rename the CI workflow from graalvm17 to just graalvm
- Remove unnecessary dependency management config and build config for the
  GraalVM profile, and instead use the configuration from the parent POM.
- Remove unnecessary values from reflect config.