### PR TITLE
chore: remove error prone rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,12 +42,6 @@
       commitMessagePrefix: 'chore(deps):',
     },
     {
-      groupName: 'error-prone-core',
-      matchPackageNames: [
-        '/^com.google.errorprone:error_prone_core/',
-      ],
-    },
-    {
       groupName: 'junit platform dependencies',
       matchPackageNames: [
         '/^org.junit.platform:/',


### PR DESCRIPTION
Now that we have fixed the build to run error prone on later versions of Java, this rule is unnecessary.