### PR TITLE
chore: configure errorprone on JDK 21 and higher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,9 +179,9 @@
 
   <profiles>
     <profile>
-      <id>java17</id>
+      <id>java21</id>
       <activation>
-        <jdk>[17,)</jdk>
+        <jdk>[21,)</jdk>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
The latest version of errorprone requires JDK 21. So we'll just match that.