### PR TITLE
fix: use gRPC thread pool for connection info

### DIFF
--- a/alloydb-jdbc-connector/pom.xml
+++ b/alloydb-jdbc-connector/pom.xml
@@ -71,6 +71,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-alloydb-v1alpha</artifactId>
     </dependency>

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultConnectionInfoRepository.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/DefaultConnectionInfoRepository.java
@@ -16,15 +16,19 @@
 
 package com.google.cloud.alloydb;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureToListenableFuture;
 import com.google.cloud.alloydb.v1alpha.AlloyDBAdminClient;
 import com.google.cloud.alloydb.v1alpha.ClusterName;
 import com.google.cloud.alloydb.v1alpha.GenerateClientCertificateRequest;
 import com.google.cloud.alloydb.v1alpha.GenerateClientCertificateResponse;
+import com.google.cloud.alloydb.v1alpha.GetConnectionInfoRequest;
 import com.google.cloud.alloydb.v1alpha.InstanceName;
 import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
 import io.grpc.Status;
@@ -59,10 +63,26 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository, Close
   @Override
   public ListenableFuture<ConnectionInfo> getConnectionInfo(
       InstanceName instanceName, KeyPair keyPair) {
+
     ListenableFuture<com.google.cloud.alloydb.v1alpha.ConnectionInfo> infoFuture =
-        executor.submit(() -> getConnectionInfo(instanceName));
+        toListenableFuture(
+            alloyDBAdminClient
+                .getConnectionInfoCallable()
+                .futureCall(
+                    GetConnectionInfoRequest.newBuilder()
+                        .setParent(instanceName.toString())
+                        .build()));
     ListenableFuture<GenerateClientCertificateResponse> clientCertificateResponseFuture =
-        executor.submit(() -> getGenerateClientCertificateResponse(instanceName, keyPair));
+        toListenableFuture(
+            alloyDBAdminClient
+                .generateClientCertificateCallable()
+                .futureCall(
+                    GenerateClientCertificateRequest.newBuilder()
+                        .setParent(getParent(instanceName))
+                        .setCertDuration(Duration.newBuilder().setSeconds(3600 /* 1 hour */))
+                        .setPublicKey(generatePublicKeyCert(keyPair))
+                        .setUseMetadataExchange(true)
+                        .build()));
 
     return Futures.whenAllComplete(infoFuture, clientCertificateResponseFuture)
         .call(
@@ -93,35 +113,19 @@ class DefaultConnectionInfoRepository implements ConnectionInfoRepository, Close
             executor);
   }
 
+  private <T> ListenableFuture<T> toListenableFuture(ApiFuture<T> future) {
+    return Futures.catching(
+        new ApiFutureToListenableFuture<>(future),
+        Exception.class,
+        e -> {
+          throw handleException(e);
+        },
+        MoreExecutors.directExecutor());
+  }
+
   @Override
   public void close() {
     this.alloyDBAdminClient.close();
-  }
-
-  private com.google.cloud.alloydb.v1alpha.ConnectionInfo getConnectionInfo(
-      InstanceName instanceName) {
-    try {
-      return alloyDBAdminClient.getConnectionInfo(instanceName);
-    } catch (Exception e) {
-      throw handleException(e);
-    }
-  }
-
-  private GenerateClientCertificateResponse getGenerateClientCertificateResponse(
-      InstanceName instanceName, KeyPair keyPair) {
-    GenerateClientCertificateRequest request =
-        GenerateClientCertificateRequest.newBuilder()
-            .setParent(getParent(instanceName))
-            .setCertDuration(Duration.newBuilder().setSeconds(3600 /* 1 hour */))
-            .setPublicKey(generatePublicKeyCert(keyPair))
-            .setUseMetadataExchange(true)
-            .build();
-
-    try {
-      return alloyDBAdminClient.generateClientCertificate(request);
-    } catch (Exception e) {
-      throw handleException(e);
-    }
   }
 
   private RuntimeException handleException(Exception e) {

--- a/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/InternalConnectorRegistry.java
+++ b/alloydb-jdbc-connector/src/main/java/com/google/cloud/alloydb/InternalConnectorRegistry.java
@@ -61,14 +61,10 @@ enum InternalConnectorRegistry implements Closeable {
   private static final String USER_AGENT = "alloydb-java-connector/" + Version.VERSION;
 
   InternalConnectorRegistry() {
-    // During refresh, each instance consumes 2 threads from the thread pool. By using 8 threads,
-    // there should be enough free threads so that there will not be a deadlock. Most users
-    // configure 3 or fewer instances, requiring 6 threads during refresh. By setting
-    // this to 8, it's enough threads for most users, plus a safety factor of 2.
     this.executor =
         MoreExecutors.listeningDecorator(
             Executors.newScheduledThreadPool(
-                8,
+                2,
                 r -> {
                   Thread t = new Thread(r);
                   t.setDaemon(true);

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,11 @@
         <version>2.75.0</version>
       </dependency>
       <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>common</artifactId>
+        <version>2.55.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-common-protos</artifactId>
         <version>2.66.0</version>


### PR DESCRIPTION
This commit uses the internal gRPC thread pool for retrieving an ephemeral certificate and connection info. As a result, we no longer need two threads per AlloyDB instance to avoid blocking the thread pool.